### PR TITLE
adding local collections alias step; depends on solrcloud playbook pr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install:
   - cd ansible-playbook-solrcloud
   - make build
-  - bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8081/solr)" != "302" ]]; do sleep 5; done'
+  - bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8090/solr)" != "302" ]]; do sleep 5; done'
   - make create-local-collections
   - make create-local-aliases
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ before_install:
 
 install:
   - cd ansible-playbook-solrcloud
-  - make up
+  - make build
   - bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8081/solr)" != "302" ]]; do sleep 5; done'
   - make create-local-collections
-  - make create-aliases
+  - make create-local-aliases
   - cd ..
 
 script:


### PR DESCRIPTION
What this PR does:
- updates step to run build + creation of local configsets, collections, aliases for travis testing. This just means it checkouts (via git) & builds / loads untagged solr configs into the test solrcloud.

Blocked by tulibraries/ansible-playbook-solrcloud#13 (rerun travis after that's merged)