### PR TITLE
updating autocommit to better support batch indexer of catalog data

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -43,4 +43,6 @@ echo
 echo "***"
 echo "* Pushing zip file asset to GitHub release."
 echo "***"
-curl -v -X POST -H "Authorization: token $GITHUB_TOKEN" --data-binary @/home/circleci/solrconfig.zip -H "Content-Type: application/octet-stream" "https://uploads.github.com/repos/tulibraries/tul_cob-catalog-solr/releases/$CIRCLE_TAG/assets?name=tul_cob-catalog-$CIRCLE_TAG.zip"
+RELEASE_ID=$(curl "https://api.github.com/repos/tulibraries/tul_cob-catalog-solr/releases/latest" | jq .id)
+
+curl -v -X POST -H "Authorization: token $GITHUB_TOKEN" --data-binary @/home/circleci/solrconfig.zip -H "Content-Type: application/octet-stream" "https://uploads.github.com/repos/tulibraries/tul_cob-catalog-solr/releases/$RELEASE_ID/assets?name=tul_cob-catalog-$CIRCLE_TAG.zip"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Once the master branch has been adequately tested and reviewed, a release is cut
 2. new Collection of `tul_cob-catalog-{release-tag}-init` is created in [Production SolrCloud](https://solrcloud.tul-infra.page) w/the requisite ConfigSet (this Collection is largely ignored);
 3. a new QA alias of `tul_cob-catalog-{release-tag}-qa` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
 3. a new Stage alias of `tul_cob-catalog-{release-tag}-stage` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
-3. a new Stage alias of `tul_cob-catalog-{release-tag}-prod` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
+3. a new Production alias of `tul_cob-catalog-{release-tag}-prod` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
 4. and, manually, a full reindex DAG is kicked off from Airflow Production to this new tul_cob-catalog alias. Upon completion of the reindex, relevant clients are redeployed pointing at their new alias, and *then QA & UAT review occur*.
 
 See the process outlined here: https://github.com/tulibraries/grittyOps/blob/master/services/solrcloud.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Funnel Cake (funcake) Solr Configurations
+# TUL COB Catalog Solr Configurations
+[![CircleCI](https://circleci.com/gh/tulibraries/tul_cob-catalog-solr.svg?style=svg)](https://circleci.com/gh/tulibraries/tul_cob-catalog-solr)
 
-These are the Solr configuration files for the Funnel Cake (PA Digital) internal metadata search & faceting Solr collection.
+These are the Solr configuration files for the TUL Cob (LibrarySearch) Alma catalog content search & faceting Solr collection.
 
 ## Prerequisites
 
@@ -9,58 +10,55 @@ These are the Solr configuration files for the Funnel Cake (PA Digital) internal
 
 ## Local Testing / Development
 
-You need a local SolrCloud cluster running to load these into. For example, use the make commands + docker-compose file in https://github.com/tulibraries/ansible-playbook-solrcloud to start a cluster. That repository's makefile includes this set of configurations and collection (funcake) in its `make create-release-collections` and `make create-aliases` commands.
+You need a local SolrCloud cluster running to load these into. For example, use the make commands + docker-compose file in https://github.com/tulibraries/ansible-playbook-solrcloud to start a cluster. That repository's makefile includes this set of configurations and collection (tul_cob-catalog) in its `make create-release-collections` and `make create-aliases` commands.
 
 If you want to go through those steps yourself, once you have a working SolrCloud cluster:
 
 1. clone this repository locally & change into the top level directory of the repository
 
 ```
-$ git clone https://github.com/tulibraries/funcake-solr.git
-$ cd funcake-solr
+$ git clone https://github.com/tulibraries/tul_cob-catalog-solr.git
+$ cd tul_cob-catalog-solr
 ```
 
 2. zip the contents of this repository *without* the top-level directory
 
 ```
-$ zip -r - * > funcake.zip
+$ zip -r - * > tul_cob-catalog.zip
 ```
 
 3. load the configs zip file into a new SolrCloud ConfigSet (change the solr url to whichever solr you're developing against)
 
 ```
-$ curl -X POST --header "Content-Type:application/octet-stream" --data-binary @funcake.zip "http://localhost:8081/solr/admin/configs?action=UPLOAD&name=funcake"
+$ curl -X POST --header "Content-Type:application/octet-stream" --data-binary @tul_cob-catalog.zip "http://localhost:8081/solr/admin/configs?action=UPLOAD&name=tul_cob-catalog"
 ```
 
 4. create a new SolrCloud Collection using that ConfigSet (change the solr url to whichever solr you're developing against)
 
 ```
-$ curl "http://localhost:8081/solr/admin/collections?action=CREATE&name=funcake-v0.1&numShards=1&replicationFactor=3&maxShardsPerNode=1&collection.configName=funcake"
+$ curl "http://localhost:8090/solr/admin/collections?action=CREATE&name=tul_cob-catalog-1&numShards=1&replicationFactor=2&maxShardsPerNode=1&collection.configName=tul_cob-catalog"
 ```
 
 5. create a new SolrCloud Alias pointing to that Collection (if you want to use an Alias; and change the solr url to whatever solr you're developing against):
 
 ```
-$ curl "http://localhost:8081/solr/admin/collections?action=CREATEALIAS&name=funcake-dev&collections=funcake"
+$ curl "http://localhost:8090/solr/admin/collections?action=CREATEALIAS&name=tul_cob-catalog-1-dev&collections=tul_cob-catalog-1"
 ```
 
 ## SolrCloud Deployment
 
-### Stage
-
-All PRs merged into the `master` branch get deployed to SolrCloud Stage, a place to confirm the configurations work at an infrastructure & development level. The ConfigSet & Collection are named for the _expected_ next release number. *This is not where primary UAT or QA of the data and presentation of the Solr Collection using the updated Configs live. That is the production solrcloud release, below*. Upon being merged to `master`, the following occurs:
-1. new ConfigSet of `funcake-v{latest+1}` is created in [Stage SolrCloud](https://solrcloud.stage.tul-infra.page);
-2. new Collection of `funcake-v{latest+1}` is created in [Stage SolrCloud](https://solrcloud.stage.tul-infra.page) w/the requisite ConfigSet;
-3. the existing alias of `funcake` is updated to point at the new `funcake-v{latest+1}` collection;
-4. and, manually, any test indexing (_if desired_) is kicked off from Airflow Stage to this `funcake` alias.
-
-After some time (1-4 days, as needed), the older funcake collections are removed from Stage SolrCloud.
+All PRs merged into the `master` branch are _not_ deployed anywhere. Only releases are deployed.
 
 ### Production
 
-Once a new set of configs are merged to `master` branch, deployed to Stage, and adequately reviewed, a release is cut. Upon creating the release (`v{latest+1}`), the following occurs:
-1. new ConfigSet of `funcake-v{latest+1}` is created in [Production SolrCloud](https://solrcloud.tul-infra.page);
-2. new Collection of `funcake-v{latest+1}` is created in [Production SolrCloud](https://solrcloud.tul-infra.page) w/the requisite ConfigSet;
-3. a new QA alias of `funcake-v{latest+1}-qa` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the requisite Collection;
-4. and, manually, a full reindex DAG is kicked off from Airflow Stage to this new funcake QA alias. Upon completion of the reindex, QA clients are redeployed pointing at this new alias, and *then QA & UAT review occur*.
-5. After QA review & approval, the Production alias of `funcake-v{latest+1}-prod` is created manually, and the alias is pointed to the `funcake-v{latest+1}` collection just reviewed in QA. Stage Client apps are updated to point at this new alias, re-deployed, reviewed, and then prod clients are updated, reviewed, and redeployed to point at this new alias.
+Once the master branch has been adequately tested and reviewed, a release is cut. Upon creating the release tag (generally just an integer), the following occurs:
+1. new ConfigSet of `tul_cob-catalog-{release-tag}` is created in [Production SolrCloud](https://solrcloud.tul-infra.page);
+2. new Collection of `tul_cob-catalog-{release-tag}-init` is created in [Production SolrCloud](https://solrcloud.tul-infra.page) w/the requisite ConfigSet (this Collection is largely ignored);
+3. a new QA alias of `tul_cob-catalog-{release-tag}-qa` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
+3. a new Stage alias of `tul_cob-catalog-{release-tag}-stage` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
+3. a new Stage alias of `tul_cob-catalog-{release-tag}-prod` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
+4. and, manually, a full reindex DAG is kicked off from Airflow Production to this new tul_cob-catalog alias. Upon completion of the reindex, relevant clients are redeployed pointing at their new alias, and *then QA & UAT review occur*.
+
+See the process outlined here: https://github.com/tulibraries/grittyOps/blob/master/services/solrcloud.md
+
+After some time (1-4 days, as needed), the older tul_cob-catalog collections are manually removed from Prod SolrCloud.

--- a/solrconfig.xml
+++ b/solrconfig.xml
@@ -63,8 +63,8 @@
 
   <updateHandler class="solr.DirectUpdateHandler2">
     <autoCommit>
-       <maxDocs>20000</maxDocs>
-       <maxTime>15000</maxTime>
+       <maxDocs>1000000</maxDocs>
+       <maxTime>900000</maxTime>
        <openSearcher>false</openSearcher>
     </autoCommit>
     <autoSoftCommit>

--- a/solrconfig.xml
+++ b/solrconfig.xml
@@ -63,10 +63,16 @@
 
   <updateHandler class="solr.DirectUpdateHandler2">
     <autoCommit>
-      <maxDocs>1000000</maxDocs>
-      <maxTime>900000</maxTime>
-      <openSearcher>true</openSearcher>
+       <maxDocs>20000</maxDocs>
+       <maxTime>15000</maxTime>
+       <openSearcher>false</openSearcher>
     </autoCommit>
+    <autoSoftCommit>
+      <maxTime>9000000</maxTime>
+    </autoSoftCommit>
+    <commitWithin>
+      <softCommit>false</softCommit>
+    </commitWithin>
     <updateLog>
       <str name="dir">${solr.ulog.dir:}</str>
     </updateLog>


### PR DESCRIPTION
What this PR does:
- makes [autocommit](https://lucene.apache.org/solr/guide/8_1/updatehandlers-in-solrconfig.html#autocommit) max-es shorter
- sets opensearcher to false
- adds explicit softcommit max time & makes longer
- [sets commitWithin to false](https://lucene.apache.org/solr/guide/8_1/updatehandlers-in-solrconfig.html#commitwithin) since generally don't need NRT searching

These settings have been tested for batch loading (full reindex). being tested now for partial index. Aiming for stability & indexing performance over immediate viewability (NRT).