### PR TITLE
Remove suggest fields from schema

### DIFF
--- a/schema.xml
+++ b/schema.xml
@@ -652,9 +652,11 @@
    <copyField source="subject_addl_t" dest="opensearch_display"/>
 
 
-   <!-- for suggestions -->
-   <copyField source="*_t" dest="suggest"/>
-   <copyField source="*_facet" dest="suggest"/>
+   <!-- for suggestions
+     Suggestions are not used, and are breaking on immense fields
+     <copyField source="*_t" dest="suggest"/>
+     <copyField source="*_facet" dest="suggest"/>
+   -->
 
    <!-- Above, multiple source fields are copied to the [text] field.
 	  Another way to map multiple source fields to the same


### PR DESCRIPTION
- This was originally done when solr configs were in tul_cob, but at some point the changes were lost.
- We don't currently use suggestions and I have noticed that a lot of Docker build time is spent on them.
- Adds back the work done previously.