### PR TITLE
BL-1740 add library relevancy spec

### DIFF
--- a/solrconfig.xml
+++ b/solrconfig.xml
@@ -106,8 +106,6 @@
        <float name="tie">0.01</float>
 
        <str name="bq">pub_date_tdt:[NOW/DAY-10YEAR TO NOW/DAY]^3500.0</str>
-       <str name="bq">(library_based_boost_t:boost)^10000.0</str>
-       <str name="bq">(library_based_boost_t:no_boost)^0.001</str>
        <str name="fq">-suppress_items_b:true</str>
 
        <!-- NOT using marc_display because it is large and will slow things down for search results -->

--- a/solrconfig.xml
+++ b/solrconfig.xml
@@ -106,6 +106,8 @@
        <float name="tie">0.01</float>
 
        <str name="bq">pub_date_tdt:[NOW/DAY-10YEAR TO NOW/DAY]^3500.0</str>
+       <str name="bq">(library_based_boost_t:boost)^10000.0</str>
+       <str name="bq">(library_based_boost_t:no_boost)^0.001</str>
        <str name="fq">-suppress_items_b:true</str>
 
        <!-- NOT using marc_display because it is large and will slow things down for search results -->

--- a/spec/fixtures/presser_v2.xml
+++ b/spec/fixtures/presser_v2.xml
@@ -1,0 +1,776 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This is a special collection of records with made up ids and the exact same title.
+It is used to do a title search and verify that the first two results are not located only at PRESSER.
+
+Everything other than the id and library location will be the same for this record in order to make sure that
+the relevancy is only affected by the library location and nothing else.
+-->
+<collection xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
+  <record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>01430ccm a2200385 a 4500</leader>
+    <controlfield tag="005">20170826032413.0</controlfield>
+    <controlfield tag="008">880303t200u1951enkopc              eng d</controlfield>
+    <controlfield tag="001">PRESSER01</controlfield>
+    <datafield ind1="2" ind2="2" tag="028">
+      <subfield code="a">B. &amp; H. 17088</subfield>
+      <subfield code="b">Boosey &amp; Hawkes</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(PPT)b24436975-01tuli_inst</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(CStRLIN)ocn487248643</subfield>
+      <subfield code="9">ExL</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCLC)ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">CU</subfield>
+      <subfield code="c">CU</subfield>
+      <subfield code="d">CStRLIN</subfield>
+      <subfield code="d">PPT</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="041">
+      <subfield code="a">engger</subfield>
+      <subfield code="h">eng</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="045">
+      <subfield code="b">d1948</subfield>
+      <subfield code="b">d1951</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="079">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="090">
+      <subfield code="a">M1503.S919</subfield>
+      <subfield code="b">R35x 2000</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Stravinsky, Igor,</subfield>
+      <subfield code="d">1882-1971.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="240">
+      <subfield code="a">Rake's progress.</subfield>
+      <subfield code="s">Vocal score
+.</subfield>
+      <subfield code="l">German &amp; English.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="4" tag="245">
+      <subfield code="a">PRESSER Spec Title :</subfield>
+      <subfield code="b">a fixture for presser specs </subfield>
+      <subfield code="c">Igor Stravinsky ; a fable by W. H. Auden and Chester Kallman ; vocal score by Leopold Spinner ; deutsche Übersetzung von Fritz Schröder.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="254">
+      <subfield code="a">Klavierauszug.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">London ;</subfield>
+      <subfield code="a">New York :</subfield>
+      <subfield code="b">Boosey &amp; Hawkes</subfield>
+      <subfield code="c">[200-], 1951.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">1 vocal score (240 p.) ;</subfield>
+      <subfield code="c">31 cm.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Operas</subfield>
+      <subfield code="v">Vocal scores with piano.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Auden, W. H.</subfield>
+      <subfield code="q">(Wystan Hugh),</subfield>
+      <subfield code="d">1907-1973.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Kallman, Chester,</subfield>
+      <subfield code="d">1921-1975.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Spinner, Leopold.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">160914</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="907">
+      <subfield code="a">.b24436975</subfield>
+      <subfield code="b">multi</subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">pstk </subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">mupll</subfield>
+      <subfield code="a">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="b">1</subfield>
+      <subfield code="c">020315</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">c</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">4</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="a">03/15/02</subfield>
+      <subfield code="s">RLIN</subfield>
+      <subfield code="c">DH</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ADM">
+      <subfield code="b">2018-06-20 01:09:33</subfield>
+      <subfield code="e">b24436975-01tuli_inst</subfield>
+      <subfield code="d">ILS</subfield>
+      <subfield code="a">2017-06-20 06:41:36</subfield>
+      <subfield code="c">false</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="HLD">
+      <subfield code="b">PRESSER</subfield>
+      <subfield code="c">plc</subfield>
+      <subfield code="h">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="8">22252761310003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22252761310003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">8</subfield>
+      <subfield code="g">plc</subfield>
+      <subfield code="t">SCORE</subfield>
+      <subfield code="9">39074029678786</subfield>
+      <subfield code="e">plc</subfield>
+      <subfield code="8">23252761300003811</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2017-06-20 06:41:36</subfield>
+      <subfield code="i">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="d">PRESSER</subfield>
+      <subfield code="f">PRESSER</subfield>
+    </datafield>
+  </record>
+  <record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>01430ccm a2200385 a 4500</leader>
+    <controlfield tag="005">20170826032413.0</controlfield>
+    <controlfield tag="008">880303t200u1951enkopc              eng d</controlfield>
+    <controlfield tag="001">PRESSER02</controlfield>
+    <datafield ind1="2" ind2="2" tag="028">
+      <subfield code="a">B. &amp; H. 17088</subfield>
+      <subfield code="b">Boosey &amp; Hawkes</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(PPT)b24436975-01tuli_inst</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(CStRLIN)ocn487248643</subfield>
+      <subfield code="9">ExL</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCLC)ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">CU</subfield>
+      <subfield code="c">CU</subfield>
+      <subfield code="d">CStRLIN</subfield>
+      <subfield code="d">PPT</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="041">
+      <subfield code="a">engger</subfield>
+      <subfield code="h">eng</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="045">
+      <subfield code="b">d1948</subfield>
+      <subfield code="b">d1951</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="079">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="090">
+      <subfield code="a">M1503.S919</subfield>
+      <subfield code="b">R35x 2000</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Stravinsky, Igor,</subfield>
+      <subfield code="d">1882-1971.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="240">
+      <subfield code="a">Rake's progress.</subfield>
+      <subfield code="s">Vocal score
+.</subfield>
+      <subfield code="l">German &amp; English.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="4" tag="245">
+      <subfield code="a">PRESSER Spec Title :</subfield>
+      <subfield code="b">a fixture for presser specs </subfield>
+      <subfield code="c">Igor Stravinsky ; a fable by W. H. Auden and Chester Kallman ; vocal score by Leopold Spinner ; deutsche Übersetzung von Fritz Schröder.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="254">
+      <subfield code="a">Klavierauszug.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">London ;</subfield>
+      <subfield code="a">New York :</subfield>
+      <subfield code="b">Boosey &amp; Hawkes</subfield>
+      <subfield code="c">[200-], 1951.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">1 vocal score (240 p.) ;</subfield>
+      <subfield code="c">31 cm.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Operas</subfield>
+      <subfield code="v">Vocal scores with piano.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Auden, W. H.</subfield>
+      <subfield code="q">(Wystan Hugh),</subfield>
+      <subfield code="d">1907-1973.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Kallman, Chester,</subfield>
+      <subfield code="d">1921-1975.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Spinner, Leopold.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">160914</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="907">
+      <subfield code="a">.b24436975</subfield>
+      <subfield code="b">multi</subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">pstk </subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">mupll</subfield>
+      <subfield code="a">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="b">1</subfield>
+      <subfield code="c">020315</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">c</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">4</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="a">03/15/02</subfield>
+      <subfield code="s">RLIN</subfield>
+      <subfield code="c">DH</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ADM">
+      <subfield code="b">2018-06-20 01:09:33</subfield>
+      <subfield code="e">b24436975-01tuli_inst</subfield>
+      <subfield code="d">ILS</subfield>
+      <subfield code="a">2017-06-20 06:41:36</subfield>
+      <subfield code="c">false</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="HLD">
+      <subfield code="b">PRESSER</subfield>
+      <subfield code="c">plc</subfield>
+      <subfield code="h">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="8">22252761310003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22252761310003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">8</subfield>
+      <subfield code="g">plc</subfield>
+      <subfield code="t">SCORE</subfield>
+      <subfield code="9">39074029678786</subfield>
+      <subfield code="e">plc</subfield>
+      <subfield code="8">23252761300003811</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2017-06-20 06:41:36</subfield>
+      <subfield code="i">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="d">PRESSER</subfield>
+      <subfield code="f">PRESSER</subfield>
+    </datafield>
+  </record>
+  <record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>01430ccm a2200385 a 4500</leader>
+    <controlfield tag="005">20170826032413.0</controlfield>
+    <controlfield tag="008">880303t200u1951enkopc              eng d</controlfield>
+    <controlfield tag="001">PRESSER03</controlfield>
+    <datafield ind1="2" ind2="2" tag="028">
+      <subfield code="a">B. &amp; H. 17088</subfield>
+      <subfield code="b">Boosey &amp; Hawkes</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(PPT)b24436975-01tuli_inst</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(CStRLIN)ocn487248643</subfield>
+      <subfield code="9">ExL</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCLC)ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">CU</subfield>
+      <subfield code="c">CU</subfield>
+      <subfield code="d">CStRLIN</subfield>
+      <subfield code="d">PPT</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="041">
+      <subfield code="a">engger</subfield>
+      <subfield code="h">eng</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="045">
+      <subfield code="b">d1948</subfield>
+      <subfield code="b">d1951</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="079">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="090">
+      <subfield code="a">M1503.S919</subfield>
+      <subfield code="b">R35x 2000</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Stravinsky, Igor,</subfield>
+      <subfield code="d">1882-1971.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="240">
+      <subfield code="a">Rake's progress.</subfield>
+      <subfield code="s">Vocal score
+.</subfield>
+      <subfield code="l">German &amp; English.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="4" tag="245">
+      <subfield code="a">PRESSER Spec Title :</subfield>
+      <subfield code="b">a fixture for presser specs </subfield>
+      <subfield code="c">Igor Stravinsky ; a fable by W. H. Auden and Chester Kallman ; vocal score by Leopold Spinner ; deutsche Übersetzung von Fritz Schröder.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="254">
+      <subfield code="a">Klavierauszug.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">London ;</subfield>
+      <subfield code="a">New York :</subfield>
+      <subfield code="b">Boosey &amp; Hawkes</subfield>
+      <subfield code="c">[200-], 1951.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">1 vocal score (240 p.) ;</subfield>
+      <subfield code="c">31 cm.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Operas</subfield>
+      <subfield code="v">Vocal scores with piano.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Auden, W. H.</subfield>
+      <subfield code="q">(Wystan Hugh),</subfield>
+      <subfield code="d">1907-1973.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Kallman, Chester,</subfield>
+      <subfield code="d">1921-1975.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Spinner, Leopold.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">160914</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="907">
+      <subfield code="a">.b24436975</subfield>
+      <subfield code="b">multi</subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">pstk </subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">mupll</subfield>
+      <subfield code="a">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="b">1</subfield>
+      <subfield code="c">020315</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">c</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">4</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="a">03/15/02</subfield>
+      <subfield code="s">RLIN</subfield>
+      <subfield code="c">DH</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ADM">
+      <subfield code="b">2018-06-20 01:09:33</subfield>
+      <subfield code="e">b24436975-01tuli_inst</subfield>
+      <subfield code="d">ILS</subfield>
+      <subfield code="a">2017-06-20 06:41:36</subfield>
+      <subfield code="c">false</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="HLD">
+      <subfield code="b">PRESSER</subfield>
+      <subfield code="c">plc</subfield>
+      <subfield code="h">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="8">22252761310003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22252761310003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">8</subfield>
+      <subfield code="g">plc</subfield>
+      <subfield code="t">SCORE</subfield>
+      <subfield code="9">39074029678786</subfield>
+      <subfield code="e">plc</subfield>
+      <subfield code="8">23252761300003811</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2017-06-20 06:41:36</subfield>
+      <subfield code="i">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="d">PRESSER</subfield>
+      <subfield code="f">PRESSER</subfield>
+    </datafield>
+  </record>
+  <record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>01430ccm a2200385 a 4500</leader>
+    <controlfield tag="005">20170826032413.0</controlfield>
+    <controlfield tag="008">880303t200u1951enkopc              eng d</controlfield>
+    <controlfield tag="001">MAIN02</controlfield>
+    <datafield ind1="2" ind2="2" tag="028">
+      <subfield code="a">B. &amp; H. 17088</subfield>
+      <subfield code="b">Boosey &amp; Hawkes</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(PPT)b24436975-01tuli_inst</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(CStRLIN)ocn487248643</subfield>
+      <subfield code="9">ExL</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCLC)ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">CU</subfield>
+      <subfield code="c">CU</subfield>
+      <subfield code="d">CStRLIN</subfield>
+      <subfield code="d">PPT</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="041">
+      <subfield code="a">engger</subfield>
+      <subfield code="h">eng</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="045">
+      <subfield code="b">d1948</subfield>
+      <subfield code="b">d1951</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="079">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="090">
+      <subfield code="a">M1503.S919</subfield>
+      <subfield code="b">R35x 2000</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Stravinsky, Igor,</subfield>
+      <subfield code="d">1882-1971.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="240">
+      <subfield code="a">Rake's progress.</subfield>
+      <subfield code="s">Vocal score
+.</subfield>
+      <subfield code="l">German &amp; English.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="4" tag="245">
+      <subfield code="a">PRESSER Spec Title :</subfield>
+      <subfield code="b">a fixture for presser specs </subfield>
+      <subfield code="c">Igor Stravinsky ; a fable by W. H. Auden and Chester Kallman ; vocal score by Leopold Spinner ; deutsche Übersetzung von Fritz Schröder.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="254">
+      <subfield code="a">Klavierauszug.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">London ;</subfield>
+      <subfield code="a">New York :</subfield>
+      <subfield code="b">Boosey &amp; Hawkes</subfield>
+      <subfield code="c">[200-], 1951.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">1 vocal score (240 p.) ;</subfield>
+      <subfield code="c">31 cm.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Operas</subfield>
+      <subfield code="v">Vocal scores with piano.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Auden, W. H.</subfield>
+      <subfield code="q">(Wystan Hugh),</subfield>
+      <subfield code="d">1907-1973.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Kallman, Chester,</subfield>
+      <subfield code="d">1921-1975.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Spinner, Leopold.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">160914</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="907">
+      <subfield code="a">.b24436975</subfield>
+      <subfield code="b">multi</subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">pstk </subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">mupll</subfield>
+      <subfield code="a">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="b">1</subfield>
+      <subfield code="c">020315</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">c</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">4</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="a">03/15/02</subfield>
+      <subfield code="s">RLIN</subfield>
+      <subfield code="c">DH</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ADM">
+      <subfield code="b">2018-06-20 01:09:33</subfield>
+      <subfield code="e">b24436975-01tuli_inst</subfield>
+      <subfield code="d">ILS</subfield>
+      <subfield code="a">2017-06-20 06:41:36</subfield>
+      <subfield code="c">false</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="HLD">
+      <subfield code="b">PRESSER</subfield>
+      <subfield code="c">plc</subfield>
+      <subfield code="h">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="8">22252761310003811</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="HLD">
+      <subfield code="b">MAIN</subfield>
+      <subfield code="c">plc</subfield>
+      <subfield code="h">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="8">22252761310003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22252761310003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">8</subfield>
+      <subfield code="g">plc</subfield>
+      <subfield code="t">SCORE</subfield>
+      <subfield code="9">39074029678786</subfield>
+      <subfield code="e">plc</subfield>
+      <subfield code="8">23252761300003811</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2017-06-20 06:41:36</subfield>
+      <subfield code="i">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="d">PRESSER</subfield>
+      <subfield code="f">PRESSER</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22252761310003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">8</subfield>
+      <subfield code="g">plc</subfield>
+      <subfield code="t">SCORE</subfield>
+      <subfield code="9">39074029678786</subfield>
+      <subfield code="e">plc</subfield>
+      <subfield code="8">23252761300003811</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2017-06-20 06:41:36</subfield>
+      <subfield code="i">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="f">MAIN</subfield>
+    </datafield>
+  </record>
+  <record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>01430ccm a2200385 a 4500</leader>
+    <controlfield tag="005">20170826032413.0</controlfield>
+    <controlfield tag="008">880303t200u1951enkopc              eng d</controlfield>
+    <controlfield tag="001">MAIN01</controlfield>
+    <datafield ind1="2" ind2="2" tag="028">
+      <subfield code="a">B. &amp; H. 17088</subfield>
+      <subfield code="b">Boosey &amp; Hawkes</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(PPT)b24436975-01tuli_inst</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(CStRLIN)ocn487248643</subfield>
+      <subfield code="9">ExL</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCLC)ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">CU</subfield>
+      <subfield code="c">CU</subfield>
+      <subfield code="d">CStRLIN</subfield>
+      <subfield code="d">PPT</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="041">
+      <subfield code="a">engger</subfield>
+      <subfield code="h">eng</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="045">
+      <subfield code="b">d1948</subfield>
+      <subfield code="b">d1951</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="079">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="090">
+      <subfield code="a">M1503.S919</subfield>
+      <subfield code="b">R35x 2000</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Stravinsky, Igor,</subfield>
+      <subfield code="d">1882-1971.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="240">
+      <subfield code="a">Rake's progress.</subfield>
+      <subfield code="s">Vocal score
+.</subfield>
+      <subfield code="l">German &amp; English.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="4" tag="245">
+      <subfield code="a">PRESSER Spec Title :</subfield>
+      <subfield code="b">a fixture for presser specs </subfield>
+      <subfield code="c">Igor Stravinsky ; a fable by W. H. Auden and Chester Kallman ; vocal score by Leopold Spinner ; deutsche Übersetzung von Fritz Schröder.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="254">
+      <subfield code="a">Klavierauszug.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">London ;</subfield>
+      <subfield code="a">New York :</subfield>
+      <subfield code="b">Boosey &amp; Hawkes</subfield>
+      <subfield code="c">[200-], 1951.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">1 vocal score (240 p.) ;</subfield>
+      <subfield code="c">31 cm.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Operas</subfield>
+      <subfield code="v">Vocal scores with piano.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Auden, W. H.</subfield>
+      <subfield code="q">(Wystan Hugh),</subfield>
+      <subfield code="d">1907-1973.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Kallman, Chester,</subfield>
+      <subfield code="d">1921-1975.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Spinner, Leopold.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">160914</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="907">
+      <subfield code="a">.b24436975</subfield>
+      <subfield code="b">multi</subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">pstk </subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">mupll</subfield>
+      <subfield code="a">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocn229901761</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="b">1</subfield>
+      <subfield code="c">020315</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">c</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">4</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="a">03/15/02</subfield>
+      <subfield code="s">RLIN</subfield>
+      <subfield code="c">DH</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ADM">
+      <subfield code="b">2018-06-20 01:09:33</subfield>
+      <subfield code="e">b24436975-01tuli_inst</subfield>
+      <subfield code="d">ILS</subfield>
+      <subfield code="a">2017-06-20 06:41:36</subfield>
+      <subfield code="c">false</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="HLD">
+      <subfield code="b">MAIN</subfield>
+      <subfield code="c">plc</subfield>
+      <subfield code="h">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="8">22252761310003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22252761310003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">8</subfield>
+      <subfield code="g">plc</subfield>
+      <subfield code="t">SCORE</subfield>
+      <subfield code="9">39074029678786</subfield>
+      <subfield code="e">plc</subfield>
+      <subfield code="8">23252761300003811</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2017-06-20 06:41:36</subfield>
+      <subfield code="i">Boosey and Hawkes BH 17088</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="f">MAIN</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/spec/relevance/library_boost_spec.rb
+++ b/spec/relevance/library_boost_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+# This spec relies on the contents of spec/fixtures/presser_v2.xml.
+# That file contains 5 records each with the exact same field values except for HLDb and id.
+RSpec.describe "Describe library boosting config" do
+  solr = RSolr.connect(url: ENV["SOLR_URL"])
+  let(:docs) { response.dig("response", "docs") || [] }
+
+  context "a title search for items at PRESSER or MAIN " do
+    let(:response) { solr.get("search", params: { q: "title:PRESSER Spec Title"})}
+
+    it "returns a doc located in MAIN as the first result" do
+      expect(docs.first["id"]).to match(/^MAIN/)
+    end
+
+    it "returns a doc located in MAIN as the second result" do
+      expect(docs[1]["id"]).to match(/^MAIN/)
+    end
+
+    it "returns a doc located in PRESSER as the last result" do
+      expect(docs.last["id"]).to match(/^PRESSER/)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds specs to guard against changes to the relevancy configuration with regards to library boosting.

I showed in a temporary PR that we in fact are not properly testing the library boosting configuration since removing the configuration for library boosting does not result in a failure of the specs: #139.

I have used the same trick of removing the library boosting configuration to show that the specs will fail if the configuration is not present (verify by taking a look at the spec results for the first commit on this branch).