### PR TITLE
Fixes call number searches not working.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem "rsolr"
 gem "rspec"
 gem "cob_index",
   git: "https://github.com/tulibraries/cob_index.git",
-  tag: "v0.11.3"
+  tag: "v0.12.0"
 gem "alma"
 gem "lc_solr_sortable", git: "https://github.com/tulibraries/lc_solr_sortable", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/tulibraries/cob_index.git
-  revision: 5633911e06947503172b13cdb568ba291820dd30
-  tag: v0.11.3
+  revision: adea8dcf1b9b14917bf4b75a6725d2f1be2ed66e
+  tag: v0.12.0
   specs:
     cob_index (0.1.0)
       gli (~> 2.18)
@@ -77,6 +77,8 @@ GEM
     mini_mime (1.1.2)
     minitest (5.17.0)
     multi_xml (0.6.0)
+    nokogiri (1.14.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
@@ -125,6 +127,7 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-linux
 
@@ -136,4 +139,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.3.26
+   2.4.6

--- a/schema.xml
+++ b/schema.xml
@@ -259,6 +259,14 @@
 
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
     <fieldType name="location" class="solr.LatLonPointSpatialField" docValues="true" />
+
+    <!-- For fields you do not want split into tokens -->
+    <fieldType name="simple_string" class="solr.TextField" omitNorms="true">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory" />
+      </analyzer>
+    </fieldType>
  </types>
 
 
@@ -324,6 +332,7 @@
 
    <field name="work_access_point" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="purchase_order" type="boolean" indexed="false" stored="true" multiValued="false" default="false" />
+   <field name="call_number_t" type="string" indexed="true" stored="true" multiValued="true"/>
 
 
    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields

--- a/spec/fixtures/test_search_call_number_search.xml
+++ b/spec/fixtures/test_search_call_number_search.xml
@@ -1,0 +1,535 @@
+<?xml version="1.0"?>
+<records>
+  <record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>02466cam a2200517Ia 4500</leader>
+    <controlfield tag="005">20230120115427.0</controlfield>
+    <controlfield tag="008">820204s1960    nyu      ck   000 0 eng d</controlfield>
+    <controlfield tag="001">991003128809703811</controlfield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(PPT)b56183604-01tuli_inst</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)8126114</subfield>
+      <subfield code="z">(OCoLC)27883485</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)8126114</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">KSU</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="c">KSU</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">NYP</subfield>
+      <subfield code="d">MVP</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">OCLCF</subfield>
+      <subfield code="d">PPT</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="043">
+      <subfield code="a">n-us---</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="079">
+      <subfield code="a">ocm08126114</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="090">
+      <subfield code="a">ML128.A4</subfield>
+      <subfield code="b">T48 1960</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="110">
+      <subfield code="a">American Society of Composers, Authors and Publishers.</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/names/n81124488</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">30 years of motion picture music :</subfield>
+      <subfield code="b">the big Hollywood hit tunes since 1928.</subfield>
+    </datafield>
+    <datafield ind1="3" ind2=" " tag="246">
+      <subfield code="a">Thirty years of motion picture music</subfield>
+    </datafield>
+    <datafield ind1="3" ind2="0" tag="246">
+      <subfield code="a">Big Hollywood hit tunes since 1928</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="264">
+      <subfield code="a">New York :</subfield>
+      <subfield code="b">American Society of Composers, Authors and Publishers,</subfield>
+      <subfield code="c">[1960?]</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">135 pages, xv ;</subfield>
+      <subfield code="c">28 cm</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="336">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="337">
+      <subfield code="a">unmediated</subfield>
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="338">
+      <subfield code="a">volume</subfield>
+      <subfield code="b">nc</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Cover title.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Recordings arranged chronologically by year and alphabetically in the title index.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="583">
+      <subfield code="a">committed to retain</subfield>
+      <subfield code="c">20220317</subfield>
+      <subfield code="d">20310630</subfield>
+      <subfield code="f">EAST</subfield>
+      <subfield code="u">http://eastlibraries.org/retained-materials</subfield>
+      <subfield code="5">PPT</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Popular music</subfield>
+      <subfield code="z">United States.</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/subjects/sh85088876</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Popular music.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">https://id.worldcat.org/fast/1071422</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Sound recordings</subfield>
+      <subfield code="v">Catalogs.</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/subjects/sh85125394</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Sound recordings.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">https://id.worldcat.org/fast/1127034</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Motion picture music</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/subjects/sh85088056</subfield>
+      <subfield code="v">Discography.</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/subjects/sh00007650</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Motion picture music.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">https://id.worldcat.org/fast/1027201</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="651">
+      <subfield code="a">United States.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">https://id.worldcat.org/fast/1204155</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Catalogs.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">https://id.worldcat.org/fast/1423692</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Discographies.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">https://id.worldcat.org/fast/1423883</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Catalogs.</subfield>
+      <subfield code="2">lcgft</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/genreForms/gf2014026057</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Discographies.</subfield>
+      <subfield code="2">lcgft</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/genreForms/gf2014026088</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">140702</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">MARCIVE-BF 20190703</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="904">
+      <subfield code="a">MARCIVE-TEUM 20221209</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="907">
+      <subfield code="a">.b56183604</subfield>
+      <subfield code="b">k    </subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk </subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocm08126114</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="b">0</subfield>
+      <subfield code="c">140520</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">a</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">0</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="a">05/20/14</subfield>
+      <subfield code="s">OCLC</subfield>
+      <subfield code="c">cep </subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ADM">
+      <subfield code="b">2023-02-19 19:00:39</subfield>
+      <subfield code="e">b56183604-01tuli_inst</subfield>
+      <subfield code="d">MARCIVE</subfield>
+      <subfield code="f">20190608034513.0</subfield>
+      <subfield code="a">2017-06-20 07:46:35</subfield>
+      <subfield code="c">false</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="HLD">
+      <subfield code="b">KARDON</subfield>
+      <subfield code="c">p_remote</subfield>
+      <subfield code="h">ML128.A4</subfield>
+      <subfield code="i">T48 1960</subfield>
+      <subfield code="8">22272141360003811</subfield>
+      <subfield code="updated">2022-03-30 21:23:44</subfield>
+      <subfield code="created">2017-06-20 07:46:35</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22272141360003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">BOOK</subfield>
+      <subfield code="9">39074029684206</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23272141350003811</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="i">ML128.A4 T48 1960</subfield>
+      <subfield code="updated">2022-09-28 23:24:51</subfield>
+      <subfield code="q">2014-05-20 00:00:00</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+  </record>
+  <record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>02154nam a2200505   4500</leader>
+    <controlfield tag="005">20230120190627.0</controlfield>
+    <controlfield tag="008">880425t19881988inu      b   s001 0 eng  </controlfield>
+    <controlfield tag="001">991022348269703811</controlfield>
+    <datafield ind1=" " ind2=" " tag="010">
+      <subfield code="a">87045442</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">0253342155</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(PPT)b14619210-01tuli_inst</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">PATG88-B08107</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)16130131</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="b">eng</subfield>
+      <subfield code="d">NhD</subfield>
+      <subfield code="d">PPT</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="079">
+      <subfield code="a">ocm16130131</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="090">
+      <subfield code="a">ML128.B26F6 1988</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Fletcher, Kristine Klopfenstein.</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/names/n86116137</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="4" tag="245">
+      <subfield code="a">The Paris Conservatoire and the contest solos for bassoon /</subfield>
+      <subfield code="c">Kristine Klopfenstein Fletcher.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="263">
+      <subfield code="a">8804</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="264">
+      <subfield code="a">Bloomington :</subfield>
+      <subfield code="b">Indiana University Press,</subfield>
+      <subfield code="c">[1988]</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="4" tag="264">
+      <subfield code="c">&#xA9;1988</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">x, 142 pages ;</subfield>
+      <subfield code="c">25 cm</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="336">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="337">
+      <subfield code="a">unmediated</subfield>
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="338">
+      <subfield code="a">volume</subfield>
+      <subfield code="b">nc</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Includes index.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="504">
+      <subfield code="a">Bibliography: page (111-114).</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="583">
+      <subfield code="a">committed to retain</subfield>
+      <subfield code="c">20220317</subfield>
+      <subfield code="d">20310630</subfield>
+      <subfield code="f">EAST</subfield>
+      <subfield code="u">http://eastlibraries.org/retained-materials</subfield>
+      <subfield code="5">PPT</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Bassoon music</subfield>
+      <subfield code="v">Bibliography.</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/subjects/sh85012266</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/subjects/sh99001362</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Bassoon music.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">https://id.worldcat.org/fast/828563</subfield>
+    </datafield>
+    <datafield ind1="2" ind2="0" tag="610">
+      <subfield code="a">Conservatoire national supe&#x301;rieur de musique.</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/names/n50055164</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="610">
+      <subfield code="a">Conservatoire national supe&#x301;rieur de musique.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">https://id.worldcat.org/fast/513700</subfield>
+    </datafield>
+    <datafield ind1="2" ind2="7" tag="610">
+      <subfield code="a">Conservatoire national supe&#x301;rieur de musique.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">https://id.worldcat.org/fast/513700</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Bibliographies.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">https://id.worldcat.org/fast/1919895</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Bibliographies.</subfield>
+      <subfield code="2">lcgft</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/genreForms/gf2014026048</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">MARCIVE-BF 20190703</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="904">
+      <subfield code="a">MARCIVE-TEUM 20221209</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="907">
+      <subfield code="a">.b14619210</subfield>
+      <subfield code="b">p    </subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="935">
+      <subfield code="a">00498560</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">pstk </subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="950">
+      <subfield code="l">P</subfield>
+      <subfield code="i">04/25/88 N</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="955">
+      <subfield code="l">P</subfield>
+      <subfield code="c">0</subfield>
+      <subfield code="i">04/25/88 C</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocm16130131</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="b">1</subfield>
+      <subfield code="c">990101</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">a</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">4</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="a">04/25/88</subfield>
+      <subfield code="t">c</subfield>
+      <subfield code="s">9110</subfield>
+      <subfield code="n">PPT</subfield>
+      <subfield code="w">NHDG88B6161</subfield>
+      <subfield code="d">04/25/88</subfield>
+      <subfield code="b">AJG</subfield>
+      <subfield code="i">880425</subfield>
+      <subfield code="l">PATG</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ADM">
+      <subfield code="b">2023-02-20 00:53:53</subfield>
+      <subfield code="e">b14619210-01tuli_inst</subfield>
+      <subfield code="d">MARCIVE</subfield>
+      <subfield code="f">20190607214815.0</subfield>
+      <subfield code="a">2017-06-20 05:58:39</subfield>
+      <subfield code="c">false</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="HLD">
+      <subfield code="b">MAIN</subfield>
+      <subfield code="c">stacks</subfield>
+      <subfield code="h">ML128.B26F6 1988</subfield>
+      <subfield code="8">22238850670003811</subfield>
+      <subfield code="updated">2022-03-30 20:26:19</subfield>
+      <subfield code="created">2017-06-20 05:58:39</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22238850670003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">stacks</subfield>
+      <subfield code="t">BOOK</subfield>
+      <subfield code="9">39074005799317</subfield>
+      <subfield code="e">stacks</subfield>
+      <subfield code="8">23238850640003811</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="i">ML128.B26F6 1988</subfield>
+      <subfield code="updated">2022-09-29 02:27:31</subfield>
+      <subfield code="q">1999-02-11 00:00:00</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="f">MAIN</subfield>
+    </datafield>
+  </record>
+  <record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>00968cam a2200301   4500</leader>
+    <controlfield tag="005">20190715232828.0</controlfield>
+    <controlfield tag="008">700511c19711970nyu           000 0 eng  </controlfield>
+    <controlfield tag="001">991018101989703811</controlfield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">0393005712</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(PPT)b49061057-01tuli_inst</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="050">
+      <subfield code="a">ML60</subfield>
+      <subfield code="b">.S513</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="090">
+      <subfield code="a">ML 60 .S513 1971</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Sessions, Roger,</subfield>
+      <subfield code="d">1896-1985.</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/names/n82039539</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Questions about music.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">New York :</subfield>
+      <subfield code="b">W.W. Norton &amp; Co.,</subfield>
+      <subfield code="c">1971, c1970.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">166 pages ;</subfield>
+      <subfield code="c">20 cm</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="336">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="337">
+      <subfield code="a">unmediated</subfield>
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="338">
+      <subfield code="a">volume</subfield>
+      <subfield code="b">nc</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Music.</subfield>
+      <subfield code="0">https://id.loc.gov/authorities/subjects/sh85088762</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Music.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">https://id.worldcat.org/fast/1030269</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">111025</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">MARCIVE-BF 20190703</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="904">
+      <subfield code="a">MARCIVE-TEUM 20221209</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="907">
+      <subfield code="a">.b49061057</subfield>
+      <subfield code="b">jt   </subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="915">
+      <subfield code="a">39646</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">jtcas</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="b">1</subfield>
+      <subfield code="c">110807</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">a</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">0</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ADM">
+      <subfield code="b">2023-02-20 01:34:11</subfield>
+      <subfield code="e">b49061057-01tuli_inst</subfield>
+      <subfield code="d">MARCIVE</subfield>
+      <subfield code="f">20190607211912.0</subfield>
+      <subfield code="a">2017-06-20 07:39:23</subfield>
+      <subfield code="c">false</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="HLD">
+      <subfield code="b">JAPAN</subfield>
+      <subfield code="c">stacks</subfield>
+      <subfield code="h">ML 60 .S513 1971</subfield>
+      <subfield code="8">22270148270003811</subfield>
+      <subfield code="created">2017-06-20 07:39:23</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22270148270003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">stacks</subfield>
+      <subfield code="t">BOOK</subfield>
+      <subfield code="9">31982070237229</subfield>
+      <subfield code="e">stacks</subfield>
+      <subfield code="8">23270148260003811</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="i">ML 60 .S513 1971</subfield>
+      <subfield code="updated">2017-06-20 07:39:55</subfield>
+      <subfield code="q">2011-08-03 00:00:00</subfield>
+      <subfield code="d">JAPAN</subfield>
+      <subfield code="f">JAPAN</subfield>
+    </datafield>
+  </record>
+</records>

--- a/spec/relevance/advanced_call_number_searches_spec.rb
+++ b/spec/relevance/advanced_call_number_searches_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe "Advanced Searches Using Call Number" do
+  solr = RSolr.connect(url: ENV["SOLR_URL"])
+  let(:query) { "_query_:{!edismax qf=alma_mms_t}#{mms_id} AND _query_:{!edismax qf=call_number_t}#{call_number}"}
+
+  let(:response) { solr.get("select", params: { q: query }) }
+
+  let(:ids) { (response.dig("response", "docs") || []).map { |doc| doc.fetch("id") }.compact }
+
+
+  context "search starts with ML"  do
+    let(:mms_id) { "991003128809703811" }
+    let(:call_number) { "ML*" }
+
+    it "returns a doc with the specified mms_id" do
+      expect(ids).to eq(["991003128809703811"])
+    end
+  end
+
+  context "search starts with ML128"  do
+    let(:mms_id) { "991003128809703811" }
+    let(:call_number) { "ML128*" }
+
+    it "value a doc with the specified mms_id" do
+      expect(ids).to eq(["991003128809703811"])
+    end
+  end
+
+  context "value starts with ML128."  do
+    let(:mms_id) { "991003128809703811" }
+    let(:call_number) { "ML128.*" }
+
+    it "returns a doc with the specified mms_id" do
+      expect(ids).to eq(["991003128809703811"])
+    end
+  end
+
+  context "value starts with ML128.A"  do
+    let(:mms_id) { "991003128809703811" }
+    let(:call_number) { "ML128.*" }
+
+    it "returns a doc with the specified mms_id" do
+      expect(ids).to eq(["991003128809703811"])
+    end
+  end
+
+  context "value starts with ML128.A T48*"  do
+    let(:mms_id) { "991003128809703811" }
+    let(:call_number) { "\"ML128.A4 T48*\"" }
+
+    it "returns a doc with the specified mms_id" do
+      expect(ids).to eq(["991003128809703811"])
+    end
+  end
+
+  context "value is ML128.A4 T48 1960 "  do
+    let(:mms_id) { "991003128809703811" }
+    let(:call_number) { "\"ML128.A4 T48 1960\"" }
+
+    it "returns a doc with the specified mms_id" do
+      expect(ids).to eq(["991003128809703811"])
+    end
+  end
+
+  context "value starts with partial ML128.A4 T48 "  do
+    let(:mms_id) { "991003128809703811" }
+    let(:call_number) { "\"ML128.A4 T48*\"" }
+
+    it "returns a doc with the specified mms_id" do
+      expect(ids).to eq(["991003128809703811"])
+    end
+  end
+
+  context "value contains 1960 "  do
+    let(:mms_id) { "991003128809703811" }
+    let(:call_number) { "*1960*" }
+
+    it "returns a doc with the specified mms_id" do
+      expect(ids).to eq(["991003128809703811"])
+    end
+  end
+
+  context "value contains 1960 "  do
+    let(:mms_id) { "991003128809703811" }
+    let(:call_number) { "*1960*" }
+
+    it "returns a doc with the specified mms_id" do
+      expect(ids).to eq(["991003128809703811"])
+    end
+  end
+end
+


### PR DESCRIPTION
Call numbers are being tokenized using a white space splitter that is
messing with how they can be searched.  By updating the field type to be
a simple_string that pulls in the value as is, we minimize issues
related to call number searches.