### PR TITLE
Fix make test not working in local m1 instance.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
+export
+
 DOCKER := docker compose
+
+RUBY_VERSION := 3.3.0
+
+ifeq ($(CI), true)
+	APP_IMAGE := cimg/ruby:$(RUBY_VERSION)
+else
+	APP_IMAGE := ruby:$(RUBY_VERSION)
+endif
 
 up:
 	$(DOCKER) up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: cimg/ruby:3.3.0
+    image: ${APP_IMAGE}
     working_dir: /app
     depends_on:
       - solr


### PR DESCRIPTION
The ci/ruby:3.3.0 image is not m1 compatible.

Locally we need to override this image to use the default ruby image which is m1 compatible.